### PR TITLE
Fix width of progress bars

### DIFF
--- a/R/iterators.R
+++ b/R/iterators.R
@@ -34,7 +34,7 @@ itoken.character <- function(iterable, preprocess_function, tokenizer, chunks_nu
   it <- idiv(n = length(iterable), chunks = chunks_number)
   max_len = length(iterable)
   if (progessbar)
-    pb <- txtProgressBar(initial = -1L, min = 0, max = max_len, style = 3, width = 100)
+    pb <- txtProgressBar(initial = -1L, min = 0, max = max_len, style = 3)
   env <- environment()
   nextEl <- function() {
     n <- nextElem(it)
@@ -57,7 +57,7 @@ itoken.ifiles <- function(iterable, preprocess_function, tokenizer, progessbar =
   i <- 1
   max_len = attr(iterable, 'length', exact = FALSE)
   if (progessbar)
-    pb <- txtProgressBar(initial = -1L, min = 0L, max = max_len, style = 3, width = 100)
+    pb <- txtProgressBar(initial = -1L, min = 0L, max = max_len, style = 3)
   env <- environment()
 
   nextEl <- function() {


### PR DESCRIPTION
The width of progress bars is currently hardcoded as 100 characters. By
removing this option, the default `width = NA` option means that the
width that users have set with `options()` will be respected. In my
case, that means no overflow of the progress bar.