### PR TITLE
slight corrections to \dontrun{} examples

### DIFF
--- a/R/glove.R
+++ b/R/glove.R
@@ -44,7 +44,7 @@
 #' text8 <- read_lines(unz(temp, "text8"))
 #' it <- itoken(text8, preprocess_function = identity,
 #'              tokenizer = function(x) strsplit(x, " ", TRUE))
-#' vocab <- vocabulary(it) %>%
+#' vocab <- create_vocabulary(it) %>%
 #'  prune_vocabulary(term_count_min = 5)
 #'
 #' it <- itoken(text8, preprocess_function = identity,

--- a/R/tcm.R
+++ b/R/tcm.R
@@ -58,7 +58,7 @@ get_tcm <- function(corpus) {
 #'
 #' tokens <- movie_review$review %>% tolower %>% word_tokenizer
 #' it <- itoken(tokens)
-#' v <- create_vocabulary(jobs)
+#' v <- create_vocabulary(it)
 #' vectorizer <- vocab_vectorizer(v, grow_dtm = FALSE, skip_grams_window = 3L)
 #' tcm <- create_tcm(itoken(tokens), vectorizer)
 #'


### PR DESCRIPTION
Noticed these when running \dontrun{} example code.