### PR TITLE
Fixes #247 - LSA should not sqrt singular values

### DIFF
--- a/R/model_LSA.R
+++ b/R/model_LSA.R
@@ -88,6 +88,7 @@ LatentSemanticAnalysis = R6::R6Class(
 
       documents = svd_fit$u %*% diag(x = svd_fit$d)
       private$components_ = t(svd_fit$v %*% diag(x = svd_fit$d))
+      private$vt = svd_fit$v
       rm(svd_fit)
       rownames(documents) = rownames(x)
       colnames(private$components_) = colnames(x)
@@ -98,9 +99,9 @@ LatentSemanticAnalysis = R6::R6Class(
     transform = function(x, ...) {
       if (private$fitted) {
         stopifnot(ncol(x) == ncol(private$components_))
-        lhs = tcrossprod(private$components_)
-        rhs = as.matrix(tcrossprod(private$components_, x))
-        t(solve(lhs, rhs))
+        temp = x %*% private$vt
+        rownames(temp) = rownames(x)
+        as.matrix(temp)
       }
       else
         stop("Fit the model first woth model$fit_transform()!")
@@ -123,7 +124,8 @@ LatentSemanticAnalysis = R6::R6Class(
     n_topics = NULL,
     components_ = NULL,
     fitted = FALSE,
-    svd_method = NULL
+    svd_method = NULL,
+    vt = NULL
   )
 )
 

--- a/R/model_LSA.R
+++ b/R/model_LSA.R
@@ -86,8 +86,8 @@ LatentSemanticAnalysis = R6::R6Class(
       }
       svd_fit = fit_svd(...)
 
-      documents = svd_fit$u %*% diag(x = sqrt(svd_fit$d))
-      private$components_ = t(svd_fit$v %*% diag(x = sqrt(svd_fit$d)))
+      documents = svd_fit$u %*% diag(x = svd_fit$d)
+      private$components_ = t(svd_fit$v %*% diag(x = svd_fit$d))
       rm(svd_fit)
       rownames(documents) = rownames(x)
       colnames(private$components_) = colnames(x)

--- a/R/model_LSA.R
+++ b/R/model_LSA.R
@@ -92,6 +92,13 @@ LatentSemanticAnalysis = R6::R6Class(
       rm(svd_fit)
       rownames(documents) = rownames(x)
       colnames(private$components_) = colnames(x)
+      
+      calculate_col_var = function(x) {
+        colMeans(x * x) - colMeans(x) ^ 2
+      }
+      
+      private$explained_variance = calculate_col_var(documents)
+      private$explained_variance_ratio = private$explained_variance / sum(calculate_col_var(x))
 
       private$fitted = TRUE
       documents
@@ -118,6 +125,20 @@ LatentSemanticAnalysis = R6::R6Class(
     ),
     get_word_vectors = function() {
       .Deprecated("model$components")
+    },
+    get_explained_variance = function(){
+      if (private$fitted){
+        private$explained_variance
+      } else {
+        stop("Fit the model first with model$fit_transform()")
+      }
+    },
+    get_explained_variance_ratio = function(){
+      if (private$fitted){
+        private$explained_variance_ratio
+      } else {
+        stop("Fit the model first with model$fit_transform()")
+      }
     }
   ),
   private = list(
@@ -125,7 +146,9 @@ LatentSemanticAnalysis = R6::R6Class(
     components_ = NULL,
     fitted = FALSE,
     svd_method = NULL,
-    vt = NULL
+    vt = NULL,
+    explained_variance = NULL,
+    explained_variance_ratio = NULL
   )
 )
 

--- a/tests/testthat/test-lsa.R
+++ b/tests/testthat/test-lsa.R
@@ -15,7 +15,7 @@ vocab = prune_vocabulary(vocab, term_count_min = 5, doc_proportion_max = 0.5)
 dtm = create_dtm(it, vocab_vectorizer(vocab))
 
 # Variance explained by component over total variance of original matrix
-proportion.var.explained = function(dtm, decomp){
+proportion_var_explained = function(dtm, decomp){
   apply(decomp, 2, var) / (sum(apply(dtm, 2, var)))
 }
 
@@ -31,21 +31,21 @@ test_that("LSA", {
 })
 
 test_that("LSA decomposition quality", {
-  max.size = min(ncol(dtm), nrow(dtm) - 1)
-  model = LatentSemanticAnalysis$new(max.size)
+  max_size = min(ncol(dtm), nrow(dtm)) - 1
+  model = LatentSemanticAnalysis$new(max_size)
 
   m1 = model$fit_transform(dtm)
 
-  manual.decomp = irlba::irlba(dtm, nu = max.size, nv = max.size)
+  manual_decomp = irlba::irlba(dtm, nu = max_size, nv = max_size)
 
-  m2 = dtm %*% manual.decomp$v
+  m2 = dtm %*% manual_decomp$v
 
   expect_equal(dim(m1), dim(m2), info = "Dimensions sanity check")
 
-  expect_equal(sum(proportion.var.explained(dtm, m1)),
-               sum(proportion.var.explained(dtm, m2)), tolerance = 1e-8,
+  expect_equal(sum(model$get_explained_variance_ratio()),
+               sum(proportion_var_explained(dtm, m2)), tolerance = 1e-8,
                info = "Proportion of variance explained should match")
 
-  expect_equal(sum(proportion.var.explained(dtm, m1)), 1.0, tolerance = 1e-3,
+  expect_equal(sum(model$get_explained_variance_ratio()), 1.0, tolerance = 1e-3,
                info = "When doing non-truncated SVD, total variance explained should be ~1.0")
 })

--- a/tests/testthat/test-lsa.R
+++ b/tests/testthat/test-lsa.R
@@ -1,4 +1,5 @@
 context("lsa model")
+require(irlba)
 N = 100
 n_topics = 20
 train_ind = 1:N
@@ -13,6 +14,11 @@ vocab = prune_vocabulary(vocab, term_count_min = 5, doc_proportion_max = 0.5)
 
 dtm = create_dtm(it, vocab_vectorizer(vocab))
 
+# Variance explained by component over total variance of original matrix
+proportion.var.explained = function(dtm, decomp){
+  apply(decomp, 2, var) / (sum(apply(dtm, 2, var)))
+}
+
 test_that("LSA", {
 
   model = LatentSemanticAnalysis$new(n_topics)
@@ -24,3 +30,22 @@ test_that("LSA", {
   expect_equal(dim(model$components), c(n_topics, ncol(dtm)))
 })
 
+test_that("LSA decomposition quality", {
+  max.size = min(ncol(dtm), nrow(dtm) - 1)
+  model = LatentSemanticAnalysis$new(max.size)
+
+  m1 = model$fit_transform(dtm)
+
+  manual.decomp = irlba::irlba(dtm, nu = max.size, nv = max.size)
+
+  m2 = dtm %*% manual.decomp$v
+
+  expect_equal(dim(m1), dim(m2), info = "Dimensions sanity check")
+
+  expect_equal(sum(proportion.var.explained(dtm, m1)),
+               sum(proportion.var.explained(dtm, m2)), tolerance = 1e-8,
+               info = "Proportion of variance explained should match")
+
+  expect_equal(sum(proportion.var.explained(dtm, m1)), 1.0, tolerance = 1e-3,
+               info = "When doing non-truncated SVD, total variance explained should be ~1.0")
+})


### PR DESCRIPTION
- Take out sqrt of singular values in LSA$fit_transform
- Add tests for LSA
  - LSA$fit_transform should match manual decomp
  - Explained variance when using max dimension size for decomp (max
    number of rows and columns - 1) should be close to 1.0