### PR TITLE
Update digest package version in DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,10 +29,10 @@ Imports:
     stringi (>= 1.1.5), 
     mlapi (>= 0.1.0), 
     lgr (>= 0.2), 
-    digest (>= 0.6.39)
+    digest (>= 0.6.37)
 LinkingTo: 
     Rcpp,
-    digest (>= 0.6.39)
+    digest (>= 0.6.37)
 Suggests:
     magrittr,
     udpipe (>= 0.6),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,10 +29,10 @@ Imports:
     stringi (>= 1.1.5), 
     mlapi (>= 0.1.0), 
     lgr (>= 0.2), 
-    digest (>= 0.6.8)
+    digest (>= 0.6.37)
 LinkingTo: 
     Rcpp,
-    digest (>= 0.6.8)
+    digest (>= 0.6.37)
 Suggests:
     magrittr,
     udpipe (>= 0.6),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,10 +29,10 @@ Imports:
     stringi (>= 1.1.5), 
     mlapi (>= 0.1.0), 
     lgr (>= 0.2), 
-    digest (>= 0.6.37)
+    digest (>= 0.6.39)
 LinkingTo: 
     Rcpp,
-    digest (>= 0.6.37)
+    digest (>= 0.6.39)
 Suggests:
     magrittr,
     udpipe (>= 0.6),


### PR DESCRIPTION
Updated the digest package version requirement from 0.6.8 to 0.6.37.

Dear @dselivanov , 
I was investigating some dependency of package formatters, and I ran into problem with this build

https://github.com/insightsengineering/formatters/actions/runs/20563614119/job/59058035025

it complains about the installation of digest, i was wondering since 0.6.8 was too old, and maybe we can update the dependency here to a more recent version, 0.6.36 had problem, 

```
✖ Failed to build digest 0.6.36 (3.4s)
! Failed to build source package digest., stdout + stderr:

OE> * installing *source* package ‘digest’ ...
OE> ** this is package ‘digest’ version ‘0.6.36’
OE> ** package ‘digest’ successfully unpacked and MD5 sums checked
OE> staged installation is only possible with locking
OE> ** using non-staged installation
OE> ** libs
OE> using C compiler: ‘gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0’
OE> using C++ compiler: ‘g++ (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0’
OE> g++ -std=gnu++17 -I"/usr/local/lib/R/include" -DNDEBUG -I.  -I/usr/local/include    -fpic  -g -O2 -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -Wall -pedantic  -c SpookyV2.cpp -o SpookyV2.o
OE> gcc -std=gnu2x -I"/usr/local/lib/R/include" -DNDEBUG -I.  -I/usr/local/include    -fpic  -g -O2 -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -Wall -pedantic -c aes.c -o aes.o
OE> gcc -std=gnu2x -I"/usr/local/lib/R/include" -DNDEBUG -I.  -I/usr/local/include    -fpic  -g -O2 -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -Wall -pedantic -c blake3.c -o blake3.o
OE> gcc -std=gnu2x -I"/usr/local/lib/R/include" -DNDEBUG -I.  -I/usr/local/include    -fpic  -g -O2 -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -Wall -pedantic -c blake3_dispatch.c -o blake3_dispatch.o
OE> gcc -std=gnu2x -I"/usr/local/lib/R/include" -DNDEBUG -I.  -I/usr/local/include    -fpic  -g -O2 -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -Wall -pedantic -c blake3_portable.c -o blake3_portable.o
OE> gcc -std=gnu2x -I"/usr/local/lib/R/include" -DNDEBUG -I.  -I/usr/local/include    -fpic  -g -O2 -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -Wall -pedantic -c crc32.c -o crc32.o
OE> g++ -std=gnu++17 -I"/usr/local/lib/R/include" -DNDEBUG -I.  -I/usr/local/include    -fpic  -g -O2 -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -Wall -pedantic  -c crc32c.cpp -o crc32c.o
OE> g++ -std=gnu++17 -I"/usr/local/lib/R/include" -DNDEBUG -I.  -I/usr/local/include    -fpic  -g -O2 -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -Wall -pedantic  -c crc32c_portable.cpp -o crc32c_portable.o
OE> gcc -std=gnu2x -I"/usr/local/lib/R/include" -DNDEBUG -I.  -I/usr/local/include    -fpic  -g -O2 -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -Wall -pedantic -c digest.c -o digest.o
OE> gcc -std=gnu2x -I"/usr/local/lib/R/include" -DNDEBUG -I.  -I/usr/local/include    -fpic  -g -O2 -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -Wall -pedantic -c digest2int.c -o digest2int.o
OE> gcc -std=gnu2x -I"/usr/local/lib/R/include" -DNDEBUG -I.  -I/usr/local/include    -fpic  -g -O2 -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -Wall -pedantic -c init.c -o init.o
OE> gcc -std=gnu2x -I"/usr/local/lib/R/include" -DNDEBUG -I.  -I/usr/local/include    -fpic  -g -O2 -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -Wall -pedantic -c md5.c -o md5.o
OE> gcc -std=gnu2x -I"/usr/local/lib/R/include" -DNDEBUG -I.  -I/usr/local/include    -fpic  -g -O2 -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -Wall -pedantic -c pmurhash.c -o pmurhash.o
OE> gcc -std=gnu2x -I"/usr/local/lib/R/include" -DNDEBUG -I.  -I/usr/local/include    -fpic  -g -O2 -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -Wall -pedantic -c raes.c -o raes.o
OE> raes.c: In function ‘AESFinalizer’:
OE> raes.c:25:3: warning: implicit declaration of function ‘Free’; did you mean ‘free’? [-Wimplicit-function-declaration]
Error in "stop_task_build(state, worker)" : 
  ! Failed to build source package digest.
OE>    25 |   Free(ctx);
OE>       |   ^~~~
OE>       |   free
OE> raes.c: In function ‘AESinit’:
OE> raes.c:42:23: warning: implicit declaration of function ‘Calloc’; did you mean ‘calloc’? [-Wimplicit-function-declaration]
OE>    42 |   ctx = (aes_context*)Calloc(sizeof(*ctx), char);
OE>       |                       ^~~~~~
OE>       |                       calloc
OE> raes.c:42:44: error: expected expression before ‘char’
OE>    42 |   ctx = (aes_context*)Calloc(sizeof(*ctx), char);
OE>       |                                            ^~~~
OE> make: *** [/usr/local/lib/R/etc/Makeconf:202: raes.o] Error 1
OE> ERROR: compilation failed for package ‘digest’
OE> * removing ‘/tmp/Rtmpm2RqlQ/pkg-libc2645cc606/digest’
```

0.6.37 seems work fine.

I tracked down my issue was actually coming from elsewhere, but I saw this old version, so I made a small suggestion. 

